### PR TITLE
interpolate animation-name as part of selectors

### DIFF
--- a/style/helpers.scss
+++ b/style/helpers.scss
@@ -53,13 +53,13 @@
 
 // Keyframe animations
 @mixin keyframes($animation-name) {
-  @-webkit-keyframes $animation-name {
+  @-webkit-keyframes #{$animation-name} {
     @content;
   }
-  @-moz-keyframes $animation-name {
+  @-moz-keyframes #{$animation-name} {
     @content;
   }
-  @keyframes $animation-name {
+  @keyframes #{$animation-name} {
     @content;
   }
 }


### PR DESCRIPTION
An error occurs while being compiled in Sass 3.4.14 (Selective Steve). This modification fixes it.
